### PR TITLE
feat:full-upgradeオプションとhelpオプションの追加

### DIFF
--- a/apude
+++ b/apude
@@ -1,12 +1,49 @@
-#!/bin/bash
+#!/bin/bash -e
 
-echo "\n DO APT UPDATE \n"
-sudo apt update
-echo "\n UPDATE DONE! \n"
-echo "\n DO APT UPGRADE -Y \n"
-sudo apt upgrade -y
-echo "\n DONE! \n"
-echo "\n DO APT AUTOREMOVE - Y\n"
-sudo apt autoremove -y
-echo "\n DONE! \n"
-echo "\n FINISHED!!!!!!!!!! \n"
+onlyShowingHelp=0
+fullUpgrade=0
+
+while getopts "hf" opt; do
+    case $opt in
+        h)
+            echo "This is a ShellScript that do update with one command"
+            echo "usage:  $0 [options]"
+            echo "options"
+            echo "  -h : show this help"
+            echo "  -f : do \"apt full-upgrade\" before \"apt upgrade\""
+            echo "  If you don't use any option, I will do only \"apt upgrade\""
+            onlyShowingHelp=1
+            ;;
+        f)
+            fullUpgrade=1
+            ;;
+        \?)
+            echo "Undefined option : -$opt \n" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [ $onlyShowingHelp -eq 0 ]; then
+    echo "    DO \"APT UPDATE\""
+    sudo apt update
+    echo "    \"UPDATE\" DONE!"
+    echo ""
+    if [ $fullUpgrade -eq 1 ]; then
+        echo "    DO \"APT FULL-UPGRADE -Y\""
+        sudo apt full-upgrade -y 
+        echo "    \"FULL-UPGRADE\" DONE!"
+        echo ""
+    else
+        echo "    DO \"APT UPGRADE -Y\""
+        sudo apt upgrade -y
+        echo "    \"UPGRADE DONE!\""
+        echo ""
+    fi
+    echo "    DO \"APT AUTOREMOVE -Y\""
+    sudo apt autoremove -y
+    echo "    \"AUTOREMOVE\" DONE!"
+    echo ""
+
+    echo "    FINISHED!!!"
+fi


### PR DESCRIPTION
`-f`オプションを付与して実行したときに、`sudo apt upgrade`ではなく`sudo apt full-upgrade`を行うようにした
オプションという今までに無かった概念が生えたので、`-h`オプションでオプションを一覧できるようにした。ついでにUsageも書いた。